### PR TITLE
Support configurable session duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2
+
+- Add support for configurable credential duration via ``VAULT_CREDENTIALS_DURATION``
+
 # 1.1
 
 - Fix to Issue #2: use GNU compliant date format

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Set the Vault path to create temporary AWS credentials.  If you don't specify th
 > export VAULT_CREDENTIALS_PATH=aws/creds/my_creds_path
 ```
 
+Set the length of time you'd like your credentials to be valid for as a golang time string (``^[0-9]+(s|m|h)$``), from "1h" to "12h". If you don't specify this, the default of "1h" (one hour) will be used:
+
+```
+# Request 12-hour credentials. Optionally add this to your profile script so it's always available
+> export VAULT_CREDENTIALS_DURATION=12h
+```
+
 Authenticate against your vault instance, using your preferred method.  This example uses LDAP.
 
 ```

--- a/bin/vault_exec
+++ b/bin/vault_exec
@@ -1,12 +1,19 @@
-VAULT_EXEC_VERSION=1.1
+VAULT_EXEC_VERSION=1.2
 
 EXPIRATION_FILE=~/.aws/vault_aws_creds_expiration
 CREDENTIALS_FILE=~/.aws/vault_aws_creds
 VAULT_CREDENTIALS_PATH_DEFAULT=aws/creds/developer
+# this is also the default if not specified at all
+VAULT_CREDENTIALS_DURATION_DEFAULT=1h
 
 if [ "" == "$VAULT_CREDENTIALS_PATH" ]; then
   echo "You did not specify a VAULT_CREDENTIALS_PATH, using the default $VAULT_CREDENTIALS_PATH_DEFAULT"
   VAULT_CREDENTIALS_PATH=$VAULT_CREDENTIALS_PATH_DEFAULT
+fi
+
+if [ "" == "$VAULT_CREDENTIALS_DURATION" ]; then
+  echo "You did not specify a VAULT_CREDENTIALS_DURATION, using the default $VAULT_CREDENTIALS_DURATION_DEFAULT"
+  VAULT_CREDENTIALS_DURATION=$VAULT_CREDENTIALS_DURATION_DEFAULT
 fi
 
 if [ "$DEBUG_VAULT_EXEC" = "true" ]; then
@@ -19,7 +26,7 @@ readField() {
 }
 
 resetCredentials() {
-    vault read -format=json $VAULT_CREDENTIALS_PATH > $CREDENTIALS_FILE
+    vault write -format=json $VAULT_CREDENTIALS_PATH ttl=$VAULT_CREDENTIALS_DURATION > $CREDENTIALS_FILE
     if [ "0" -ne "$?" ]; then
         echo "Failed to get new credentials from vault!  Quitting."
         rm $CREDENTIALS_FILE


### PR DESCRIPTION
This adds support for [configurable session duration](https://aws.amazon.com/about-aws/whats-new/2018/03/longer-role-sessions/), from the default of 1 hour to the maximum of 12 hours, on roles that are configured for it. If a specific role isn't configured for it, you'll just get the default 1-hour credentials.

This seems to work for me, but I can't test it 100% because ``vault_exec`` has some errors on my system since my ``date`` command doesn't have a ``-v`` option (Arch Linux, ``date`` from GNU coreutils 8.29).