### PR TITLE
hide log messages by default

### DIFF
--- a/bin/vault_exec
+++ b/bin/vault_exec
@@ -1,13 +1,31 @@
 VAULT_EXEC_VERSION=1.3
 
+help(){
+  echo "Usage: $SCRIPT [options] (command to execute)"
+  echo "options:"
+  echo "    -h      display script help"
+  echo "    -v      verbose output (default:false)"
+  echo ""
+}
+
 EXPIRATION_FILE=~/.aws/vault_aws_creds_expiration
 CREDENTIALS_FILE=~/.aws/vault_aws_creds
 VAULT_CREDENTIALS_PATH_DEFAULT=aws/creds/developer
 # this is also the default if not specified at all
 VAULT_CREDENTIALS_DURATION_DEFAULT=1h
 
+while getopts ":vh" opt
+do
+  case $opt in
+    v ) verbose=true; shift;;
+    h ) help; exit;;
+  esac
+done
+
 log_message() {
-  (>&2 echo $@)
+  if [ ! -z $verbose ]; then
+    (>&2 echo $@)
+  fi
 }
 
 if [ "" == "$VAULT_CREDENTIALS_PATH" ]; then

--- a/bin/vault_exec
+++ b/bin/vault_exec
@@ -1,4 +1,4 @@
-VAULT_EXEC_VERSION=1.3
+VAULT_EXEC_VERSION=1.4
 
 help(){
   echo "Usage: $SCRIPT [options] (command to execute)"


### PR DESCRIPTION
when using vault_exec to pipe output to other commands the log messages break the pipes. ie 
```
vault_exec aws ..... | jq .
```
this will break cause the log messages are passed to the pipe